### PR TITLE
Hotfix/separate button variables

### DIFF
--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -13,13 +13,13 @@
     $_button-disabled-opacity           : 0.5,
     $_button-width                      : auto,
     $_button-margin                     : 0,
-    $_button-padding                    : 7px 15px,
-    $_button-color                      : $primary__color,
-    $_button-background                 : $color-gray95,
-    $_button-border                     : 1px solid $color-gray-darken2,
+    $_button-padding                    : $button__padding,
+    $_button-color                      : $button__color,
+    $_button-background                 : $button__background,
+    $_button-border                     : $button__border,
 
-    $_button-color-hover                : $color-gray-darken3,
-    $_button-background-hover           : $color-gray-darken1,
+    $_button-color-hover                : $button__hover__color,
+    $_button-background-hover           : $button__hover__background,
     $_button-border-hover               : $_button-border,
 
     $_button-color-active               : $_button-color,
@@ -125,7 +125,7 @@
 
 @mixin lib-button-size(
     $_button-line-height: $button__line-height,
-    $_button-padding    : 7px 15px
+    $_button-padding    : $button__padding
 ) {
     @include lib-line-height($_button-line-height);
     padding: $_button-padding;
@@ -269,7 +269,7 @@
     $_button-line-height                : $font-size__base + 2,
     $_button-width                      : auto,
     $_button-margin                     : 0,
-    $_button-padding                    : 7px 15px,
+    $_button-padding                    : $button__padding,
 
     $_button-color                      : $color-white,
     $_button-border                     : 1px solid $color-blue1,
@@ -361,7 +361,7 @@
 @mixin lib-button-revert-secondary-size(
     $_button-font-size  : $button__font-size,
     $_button-line-height: $button__line-height,
-    $_button-padding    : 7px 15px
+    $_button-padding    : $button__padding
 ) {
     font-size: $_button-font-size;
     @include lib-button-size(

--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -2,50 +2,6 @@
 //  Buttons
 //  _____________________________________________
 
-//
-//  Button with solid or picture background
-//  ---------------------------------------------
-
-$button-icon__position              : $icon__position !default;
-$button-icon__font                  : $icon-font !default;
-$button-icon__font-size             : 22px !default;
-$button-icon__line-height           : $button-icon__font-size !default;
-$button-icon__margin                : 0 !default;
-$button-icon__color                 : inherit !default;
-$button-icon__hover__font-color     : inherit !default;
-$button-icon__active__font-color    : inherit !default;
-
-$button__font-size                  : $font-size__base !default;
-$button__font-weight                : $font-weight__semibold !default;
-$button__line-height                : $line-height__base !default;
-
-//  Default = secondary button
-$button__background                 : $color-gray-darken0 !default;
-$button__border                     : 1px solid $border-color__base !default;
-$button__border-radius              : 3px !default;
-// $button__hover__color: $button__color;
-$button__hover__background          : darken($button__background, 5%) !default;
-$button__active__background         : $color-gray-darken1 !default;
-
-//  Primary button
-$button-primary__hover__color       : $color-white !default;
-$button-primary__active__background : $link__hover__color !default;
-$button-primary__active__border     : 1px solid $link__hover__color !default;
-$button-primary__active__color      : $color-white !default;
-
-$button__shadow                     : none !default;
-$button__shadow-active              : none !default;
-
-//  Large button
-$button__font-size__l               : $font-size__l !default;
-$button__line-height__l             : $font-size__l + 4 !default;
-$button__padding__l                 : 14px 17px !default;
-
-//  Small button
-$button__font-size__s               : 11px !default;
-$button__line-height__s             : $button__font-size__s + 1 !default;
-$button__padding__s                 : $indent__xs 8px !default;
-
 @mixin lib-button(
     $_button-font-family                : $font-family__base,
     $_button-font-size                  : $font-size__base,

--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -138,9 +138,9 @@
 //  ---------------------------------------------
 
 @mixin lib-button-l(
-    $_button-l-font-size: $font-size__l,
-    $_button-l-height   : $font-size__l + 4,
-    $_button-l-padding  : 14px 17px
+    $_button-l-font-size: $button__font-size__l,
+    $_button-l-height   : $button__line-height__l,
+    $_button-l-padding  : $button__padding__l
 ) {
     @include lib-button-size(
         $_button-line-height: $_button-l-height,
@@ -154,9 +154,9 @@
 //  ---------------------------------------------
 
 @mixin lib-button-s(
-    $_button-s-font-size: 11px,
-    $_button-s-height   : $button__font-size__s + 1,
-    $_button-s-padding  : $indent__xs 8px
+    $_button-s-font-size: $button__font-size__s,
+    $_button-s-height   : $button__line-height__s,
+    $_button-s-padding  : $button__padding__s
 ) {
     @include lib-button-size(
         $_button-line-height: $_button-s-height,

--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -269,18 +269,18 @@
     $_button-line-height                : $font-size__base + 2,
     $_button-width                      : auto,
     $_button-margin                     : 0,
-    $_button-padding                    : $button__padding,
+    $_button-padding                    : $button-primary__padding,
 
-    $_button-color                      : $color-white,
-    $_button-border                     : 1px solid $color-blue1,
-    $_button-background                 : $color-blue1,
+    $_button-color                      : $button-primary__color,
+    $_button-border                     : $button-primary__border,
+    $_button-background                 : $button-primary__background,
 
-    $_button-color-hover                : $_button-color,
-    $_button-border-hover               : $_button-border,
-    $_button-background-hover           : $color-blue2,
+    $_button-color-hover                : $button-primary__hover__color,
+    $_button-border-hover               : $button-primary__hover__border,
+    $_button-background-hover           : $button-primary__hover__background,
 
-    $_button-color-active               : $_button-color,
-    $_button-border-active              : $_button-border,
+    $_button-color-active               : $button-primary__active__color,
+    $_button-border-active              : $button-primary__active__border,
     $_button-background-active          : $button-primary__active__background,
 
     $_button-gradient                   : inherit,
@@ -324,13 +324,13 @@
 //  ---------------------------------------------
 
 @mixin lib-button-revert-secondary-color(
-    $_button-color            : $primary__color,
-    $_button-background       : $color-gray95,
-    $_button-border           : 1px solid $color-gray-darken2,
+    $_button-color            : $button__color,
+    $_button-background       : $button__background,
+    $_button-border           : $button__border,
 
-    $_button-color-hover      : $color-gray-darken3,
-    $_button-background-hover : $color-gray-darken1,
-    $_button-border-hover     : $_button-border,
+    $_button-color-hover      : $button__hover__color,
+    $_button-background-hover : $button__hover__background,
+    $_button-border-hover     : $button__active__background,
 
     $_button-color-active     : $_button-color,
     $_button-background-active: $_button-background-hover,

--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -3,7 +3,7 @@
 //  _____________________________________________
 
 @mixin lib-button(
-    $_button-font-family                : $font-family__base,
+    $_button-font-family                : $button__font-family,
     $_button-font-size                  : $font-size__base,
     $_button-font-weight                : $font-weight__bold,
     $_button-line-height                : $font-size__base + 2,
@@ -17,6 +17,7 @@
     $_button-color                      : $button__color,
     $_button-background                 : $button__background,
     $_button-border                     : $button__border,
+    $_button-border-radius              : $button__border-radius,
 
     $_button-color-hover                : $button__hover__color,
     $_button-background-hover           : $button__hover__background,
@@ -57,6 +58,7 @@
         $_button-gradient
     );
     border: $_button-border;
+    border-radius: $_button-border-radius;
     color: $_button-color;
     cursor: $_button-cursor;
     display: $_button-display;

--- a/styles/vendor/magento-ui/_lib.scss
+++ b/styles/vendor/magento-ui/_lib.scss
@@ -11,6 +11,7 @@
 
 @import 'variables/icons';
 @import 'variables/forms';
+@import 'variables/buttons';
 @import 'variables/typography';
 @import 'variables/layout';
 @import 'variables/messages';

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -25,7 +25,13 @@ $button__hover__background          : $color-gray-darken1 !default;
 $button__active__background         : $button__color !default;
 
 //  Primary button
+$button-primary__padding            : $button__padding !default;
+$button-primary__color              : $color-white !default;
+$button-primary__background         : $color-blue1 !default;
+$button-primary__border             : 1px solid $button-primary__background !default;
 $button-primary__hover__color       : $color-white !default;
+$button-primary__hover__background  : $color-blue2 !default;
+$button-primary__hover__border      : 1px solid $button-primary__background !default;
 $button-primary__active__background : $link__hover__color !default;
 $button-primary__active__border     : 1px solid $link__hover__color !default;
 $button-primary__active__color      : $color-white !default;

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -15,12 +15,14 @@ $button__font-weight                : $font-weight__semibold !default;
 $button__line-height                : $line-height__base !default;
 
 //  Default = secondary button
-$button__background                 : $color-gray-darken0 !default;
-$button__border                     : 1px solid $border-color__base !default;
+$button__padding                    : 7px 15px !default;
+$button__color                      : $primary__color !default;
+$button__background                 : $color-gray95 !default;
+$button__border                     : 1px solid $color-gray-darken2 !default;
 $button__border-radius              : 3px !default;
-// $button__hover__color: $button__color;
-$button__hover__background          : darken($button__background, 5%) !default;
-$button__active__background         : $color-gray-darken1 !default;
+$button__hover__color               : $color-gray-darken3 !default;
+$button__hover__background          : $color-gray-darken1 !default;
+$button__active__background         : $button__color !default;
 
 //  Primary button
 $button-primary__hover__color       : $color-white !default;

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -1,0 +1,42 @@
+//
+//  Button with solid or picture background
+//  ---------------------------------------------
+$button-icon__position              : $icon__position !default;
+$button-icon__font                  : $icon-font !default;
+$button-icon__font-size             : 22px !default;
+$button-icon__line-height           : $button-icon__font-size !default;
+$button-icon__margin                : 0 !default;
+$button-icon__color                 : inherit !default;
+$button-icon__hover__font-color     : inherit !default;
+$button-icon__active__font-color    : inherit !default;
+
+$button__font-size                  : $font-size__base !default;
+$button__font-weight                : $font-weight__semibold !default;
+$button__line-height                : $line-height__base !default;
+
+//  Default = secondary button
+$button__background                 : $color-gray-darken0 !default;
+$button__border                     : 1px solid $border-color__base !default;
+$button__border-radius              : 3px !default;
+// $button__hover__color: $button__color;
+$button__hover__background          : darken($button__background, 5%) !default;
+$button__active__background         : $color-gray-darken1 !default;
+
+//  Primary button
+$button-primary__hover__color       : $color-white !default;
+$button-primary__active__background : $link__hover__color !default;
+$button-primary__active__border     : 1px solid $link__hover__color !default;
+$button-primary__active__color      : $color-white !default;
+
+$button__shadow                     : none !default;
+$button__shadow-active              : none !default;
+
+//  Large button
+$button__font-size__l               : $font-size__l !default;
+$button__line-height__l             : $font-size__l + 4 !default;
+$button__padding__l                 : 14px 17px !default;
+
+//  Small button
+$button__font-size__s               : 11px !default;
+$button__line-height__s             : $button__font-size__s + 1 !default;
+$button__padding__s                 : $indent__xs 8px !default;

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -10,6 +10,7 @@ $button-icon__color                 : inherit !default;
 $button-icon__hover__font-color     : inherit !default;
 $button-icon__active__font-color    : inherit !default;
 
+$button__font-family                : $font-family__base !default;
 $button__font-size                  : $font-size__base !default;
 $button__font-weight                : $font-weight__semibold !default;
 $button__line-height                : $line-height__base !default;


### PR DESCRIPTION
**CW:** 336324
 
This brings in https://github.com/SnowdogApps/magento2-theme-blank-sass/pull/142 since it might be a while?

---

This PR moves the button variables inside Magento UI button block into it's own partial like we have for icons and other blocks. I also added the missing !default flag so that they can be set before and replaced some specific color variables with the appropriate button color variable.

This should make it easier to pre-set button colors in a theme _variables.scss if needed.