### PR TITLE
Fix secondary button hover variable

### DIFF
--- a/styles/vendor/magento-ui/_buttons.scss
+++ b/styles/vendor/magento-ui/_buttons.scss
@@ -21,11 +21,11 @@
 
     $_button-color-hover                : $button__hover__color,
     $_button-background-hover           : $button__hover__background,
-    $_button-border-hover               : $_button-border,
+    $_button-border-hover               : $button__hover__border,
 
     $_button-color-active               : $_button-color,
     $_button-background-active          : $_button-background-hover,
-    $_button-border-active              : $_button-border,
+    $_button-border-active              : $button__active__border,
 
     $_button-gradient                   : inherit,
     $_button-gradient-direction         : inherit,
@@ -332,11 +332,11 @@
 
     $_button-color-hover      : $button__hover__color,
     $_button-background-hover : $button__hover__background,
-    $_button-border-hover     : $button__active__background,
+    $_button-border-hover     : $button__hover__border,
 
     $_button-color-active     : $_button-color,
     $_button-background-active: $_button-background-hover,
-    $_button-border-active    : $_button-border
+    $_button-border-active    : $button__active__border
 ) {
     background: $_button-background;
     border: $_button-border;

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -23,9 +23,9 @@ $button__border                     : 1px solid $color-gray-darken2 !default;
 $button__border-radius              : 3px !default;
 $button__hover__color               : $color-gray-darken3 !default;
 $button__hover__background          : $color-gray-darken1 !default;
-$button__hover__border              : 1px solid $color-gray-darken2 !default;
+$button__hover__border              : $button__border !default;
 $button__active__background         : $button__color !default;
-$button__active__border             : 1px solid $color-gray-darken2 !default;
+$button__active__border             : $button__border !default;
 
 //  Primary button
 $button-primary__padding            : $button__padding !default;

--- a/styles/vendor/magento-ui/variables/_buttons.scss
+++ b/styles/vendor/magento-ui/variables/_buttons.scss
@@ -23,7 +23,9 @@ $button__border                     : 1px solid $color-gray-darken2 !default;
 $button__border-radius              : 3px !default;
 $button__hover__color               : $color-gray-darken3 !default;
 $button__hover__background          : $color-gray-darken1 !default;
+$button__hover__border              : 1px solid $color-gray-darken2 !default;
 $button__active__background         : $button__color !default;
+$button__active__border             : 1px solid $color-gray-darken2 !default;
 
 //  Primary button
 $button-primary__padding            : $button__padding !default;


### PR DESCRIPTION
Fixes button hover variable.

We're currently using a color as the variable for the entire `border` property, resulting in outputted CSS e.g `border: #333`. That implies a border-width of 0. This is causing issues with certain borders.

![screen recording 2017-06-02 at 03 53 pm](https://cloud.githubusercontent.com/assets/714017/26742484/d4661e48-47ab-11e7-9564-261463f2ae27.gif)
