### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "snowdog/theme-blank-sass",
     "description": "SASS based version of Magento 2 Blank theme",
-    "version": "0.10.1",
+    "version": "1.0.0",
     "license": "MIT",
     "type": "magento2-theme",
     "require": {


### PR DESCRIPTION
Let's start tagging releases here instead of bringing in the latest into projects. We're diverging from the snowdog repo, but we'll specify their version when merging in changes. 