### PR TITLE
Fix composer regression. Update composer version to 1.100.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
     "name": "snowdog/theme-blank-sass",
     "description": "SASS based version of Magento 2 Blank theme",
-    "version": "0.10.1",
+    "version": "1.100.4",
     "license": "MIT",
     "type": "magento2-theme",
     "require": {
-      "magento/framework": "100.1.0||101.0.*"
+      "magento/framework": "100.1.*||101.0.*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
The requires was updated erroneously in:

https://github.com/sdinteractive/magento2-theme-blank-sass/commit/9e8dfcf50bf001fbe782c72a4a6614a9563a5d84#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780

This should fix that.